### PR TITLE
Add in-methods-params rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Rules are divided into categories for your convenience. All rules are off by def
 These rules are purely matters of style and are quite subjective.
 * [no-rename](docs/rules/no-rename.md): Forbid rename syntax when object destructuring.
 * [in-params](docs/rules/in-params.md): Configure destructuring within parameters.
+* [in-methods-params](docs/rules/in-methods-params.md): Forbid destructuring within method parameters.
 
 # Contributing
 Contributions are always welcome!.

--- a/docs/rules/in-methods-params.md
+++ b/docs/rules/in-methods-params.md
@@ -1,0 +1,34 @@
+# in-methods-params
+
+Destructuring within params of a method can be messy, unreadable and moreover you loose an opportunity of giving a name to the param. This rule allows you to ban destructuring of params in method declarations.
+
+## Rule Details
+
+The following patterns are considered problems:
+
+```js
+/*eslint destructuring/in-methods-params: "error"*/
+
+class Test {
+  constructor({b}) {}
+  t1({b}) {}
+  static t2({b}) {}
+}
+
+```
+
+The following patterns are not considered warnings:
+
+```js
+/*eslint destructuring/in-methods-params: "error"*/
+
+class Test {
+  constructor(b) {}
+  t1(b) {}
+  static t2(b) {}
+}
+```
+
+## When Not To Use It
+
+If you think destructuring in methods params is readable then you can disable this rule.

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ module.exports = {
       rules: {
         'destructuring/no-rename': 'error',
         'destructuring/in-params': 'error',
+        'destructuring/in-methods-params': 'error',
       },
     },
   },

--- a/src/rules/in-methods-params.js
+++ b/src/rules/in-methods-params.js
@@ -1,0 +1,16 @@
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  create: function inMethodsParams(context) {
+    return {
+      ObjectPattern(node) {
+        if (node.parent && node.parent.parent &&
+          node.parent.parent.type === 'MethodDefinition') {
+          context.report(node, 'Do not use destructuring in method params.');
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/in-methods-params.js
+++ b/tests/lib/rules/in-methods-params.js
@@ -1,0 +1,45 @@
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+import { RuleTester } from 'eslint';
+import rule from '../../../src/rules/in-methods-params';
+import { test } from '../utils';
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+const errors = [{ message: 'Do not use destructuring in method params.' }];
+ruleTester.run('in-methods-params', rule, {
+  valid: [
+    test({ code: 'var { a } = b;' }),
+    test({ code: 'var { a : { c } } = b;' }),
+    test({ code: 'var { a : [ c ] } = b;' }),
+
+    test({ code: 'function t({ a, b, c }) {}' }),
+    test({ code: 'var a = ({a, b, c : { d : { e } }}) => a;' }),
+
+    test({ code: 'function t(a, b) {}' }),
+    test({ code: 'function t(a, b = (() => { const {a} = b; })) {}' }),
+
+    test({ code: 'class Test { constructor (a) {} }' }),
+    test({ code: 'class Test { someMethod (a) {} }' }),
+    test({ code: 'class Test { static someStaticMethod (a) {} }' }),
+  ],
+  invalid: [
+    test({
+      code: 'class Test { constructor ({ a }) {} }',
+      errors,
+    }),
+    test({
+      code: 'class Test { someMethod ({ a }) {} }',
+      errors,
+    }),
+    test({
+      code: 'class Test { static someStaticMethod ({ a }) {} }',
+      errors,
+    }),
+  ],
+});


### PR DESCRIPTION
That rule allows one to forbid usage of destructuring in methods params.

We've had the following situation and decided to forbid usage of destructuring in methods params completely, while still allowing it for higher order functions

The following example demonstrates rather extreme case, but it is very easy to get there by adding one field at a time.

Why is it bad?
- It can become very messy especially in a combination of max chars rule
- no opportunity to give a name to the param, which is especially bad in a class context because interface is unclear in this case

Solution
- Forbid it completely
- Do destructuring in the method body on the first line

```js
class Test {
  loadSomeDataFromServer(
    {
      url,
      anotherParam,
      oneMore,
      someFlag
    }
  ) {
    // function body goes here
  }
}
```

PS. eslint was yelling at me so I fixed indentation as well.