### PR TITLE
Allow desctructuring rename for invalid identifiers

### DIFF
--- a/docs/rules/no-rename.md
+++ b/docs/rules/no-rename.md
@@ -1,6 +1,6 @@
 # no-rename
 
-When destructuring an object, you can provide the variable name in order to have the variable name differ from the object property. This can produce confusing code that is harder to read that ES5 code, therefore this rule prevents it.
+When destructuring an object, you can provide the variable name in order to have the variable name differ from the object property. This can produce confusing code that is harder to read than ES5 code, therefore this rule prevents it unless the object property is an invalid identifier (ie. a string literal).
 
 ## Rule Details
 
@@ -21,6 +21,7 @@ The following patterns are not considered warnings:
 
 const { a } = c;
 const { a: { a }} = c;
+const { 'data-prop': a } = c;
 ```
 
 ## When Not To Use It

--- a/src/rules/no-rename.js
+++ b/src/rules/no-rename.js
@@ -13,8 +13,9 @@ module.exports = {
         if (node.parent.type === 'ObjectPattern' &&
           node.shorthand === false &&
           node.value &&
-          node.value.type === 'Identifier') {
-          context.report(node, 'Do not use destructuring rename.');
+          node.value.type === 'Identifier' &&
+          node.key.type !== 'Literal') {
+          context.report(node, 'Do not use destructuring rename for valid identifiers.');
         }
       },
     };

--- a/tests/lib/rules/no-rename.js
+++ b/tests/lib/rules/no-rename.js
@@ -11,7 +11,7 @@ import { test } from '../utils';
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester();
-const errors = [{ message: 'Do not use destructuring rename.' }];
+const errors = [{ message: 'Do not use destructuring rename for valid identifiers.' }];
 ruleTester.run('no-rename', rule, {
   valid: [
     test({ code: 'var { a } = b;' }),
@@ -21,6 +21,7 @@ ruleTester.run('no-rename', rule, {
     test({ code: 'var a = { b : b };' }),
     test({ code: 'var a = { b : c };' }),
     test({ code: 'var a = { b : { c : b } };' }),
+    test({ code: 'var { "data-prop" : a } = b;' }),
   ],
   invalid: [test({
     code: 'var { a : c } = b;',
@@ -36,6 +37,10 @@ ruleTester.run('no-rename', rule, {
     }),
     test({
       code: 'var { a : { c : d } } = b;',
+      errors,
+    }),
+    test({
+      code: 'var { "data-prop" : a, a : c } = b;',
       errors,
     })],
 });


### PR DESCRIPTION
This rule would also reject destructuring rename for invalid identifiers, thus rendering destructuring of _eg._ 'data-prop' impossible. I suggest it allows renaming in case the property is an invalid identifier.