### PR TITLE
docs: in-params: changed not valid assignment to arrow function

### DIFF
--- a/docs/rules/in-params.md
+++ b/docs/rules/in-params.md
@@ -10,12 +10,12 @@ The following patterns are considered problems:
 /*eslint destructuring/in-params: ["error", { "max-params" : 1}]*/
 
 function t1(a, {b}) {}
-const t2 = (b, {a}) = a;
+const t2 = (b, {a}) => a;
 
 /*eslint destructuring/in-params: ["error", { "max-params" : 0}]*/
 
 function t3({a}) {}
-const t4 = ({a}) = a;
+const t4 = ({a}) => a;
 
 ```
 


### PR DESCRIPTION
This code is not valid:

```
const t2 = (b, {a}) = a;
```

Sometimes because of a typo such valid code can be written as well:

```js
const createRegExp = (a) = RegExp(a, 'g');
```

You can handle such cases in `js` and `readme` files using [putout](https://github.com/coderaiser/putout) super linter with help of [@putout/plugin-convert-assignment-to-arrow-function](https://github.com/coderaiser/putout/tree/master/packages/plugin-convert-assignment-to-arrow-function).

It will fix it to:

```js
const createRegExp = (a) => RegExp(a, 'g');
```