### PR TITLE
Detect destructured params with default values

### DIFF
--- a/src/rules/in-methods-params.js
+++ b/src/rules/in-methods-params.js
@@ -6,8 +6,14 @@ module.exports = {
   create: function inMethodsParams(context) {
     return {
       ObjectPattern(node) {
-        if (node.parent && node.parent.parent &&
-          node.parent.parent.type === 'MethodDefinition') {
+        // A destructured param with a default value (e.g. `method({ a } = {}) {}`)
+        // is wrapped in an AssignmentPattern, adding an extra level above the
+        // ObjectPattern before reaching the FunctionExpression / MethodDefinition.
+        const fnNode = node.parent && node.parent.type === 'AssignmentPattern' ?
+          node.parent.parent : node.parent;
+
+        if (fnNode && fnNode.parent &&
+          fnNode.parent.type === 'MethodDefinition') {
           context.report(node, 'Do not use destructuring in method params.');
         }
       },

--- a/src/rules/in-params.js
+++ b/src/rules/in-params.js
@@ -32,9 +32,14 @@ module.exports = {
 
     return {
       ObjectPattern(node) {
-        if (node.parent.type === 'ArrowFunctionExpression' ||
-        node.parent.type === 'FunctionDeclaration') {
-          if (node.parent.params.length > maxParams) {
+        // A destructured param with a default value (e.g. `function f({ a } = {})`)
+        // is wrapped in an AssignmentPattern, so the function is the grandparent.
+        const fnNode = node.parent.type === 'AssignmentPattern' ?
+          node.parent.parent : node.parent;
+
+        if (fnNode && (fnNode.type === 'ArrowFunctionExpression' ||
+          fnNode.type === 'FunctionDeclaration')) {
+          if (fnNode.params.length > maxParams) {
             context.report(node, 'Do not use destructuring in params when there' +
               ` are more than ${maxParams} params.`);
           }

--- a/tests/lib/rules/in-methods-params.js
+++ b/tests/lib/rules/in-methods-params.js
@@ -27,6 +27,14 @@ ruleTester.run('in-methods-params', rule, {
     test({ code: 'class Test { constructor (a) {} }' }),
     test({ code: 'class Test { someMethod (a) {} }' }),
     test({ code: 'class Test { static someStaticMethod (a) {} }' }),
+
+    // Plain functions with defaults should not be flagged by the methods rule.
+    test({ code: 'function t({ a } = {}) {}' }),
+    test({ code: 'var a = ({ a } = {}) => a;' }),
+
+    // Defaults that destructure but are not method params must not match.
+    test({ code: 'class Test { someMethod (a = (() => { const {x} = a; })) {} }' }),
+    test({ code: 'class Test { someMethod (a) { var { x } = a; } }' }),
   ],
   invalid: [
     test({
@@ -39,6 +47,28 @@ ruleTester.run('in-methods-params', rule, {
     }),
     test({
       code: 'class Test { static someStaticMethod ({ a }) {} }',
+      errors,
+    }),
+
+    // Issue #46: a destructured method param with a default value also counts.
+    test({
+      code: 'class Test { constructor ({ a } = {}) {} }',
+      errors,
+    }),
+    test({
+      code: 'class Test { someMethod ({ a } = {}) {} }',
+      errors,
+    }),
+    test({
+      code: 'class Test { static someStaticMethod ({ a } = {}) {} }',
+      errors,
+    }),
+    test({
+      code: 'class Test { someMethod ({ a, b, c } = {}) {} }',
+      errors,
+    }),
+    test({
+      code: 'class Test { someMethod (a, { b } = {}) {} }',
       errors,
     }),
   ],

--- a/tests/lib/rules/in-params.js
+++ b/tests/lib/rules/in-params.js
@@ -13,6 +13,8 @@ import { test } from '../utils';
 const ruleTester = new RuleTester();
 const errors = [{ message:
   'Do not use destructuring in params when there are more than 1 params.' }];
+const errorsZero = [{ message:
+  'Do not use destructuring in params when there are more than 0 params.' }];
 ruleTester.run('in-params', rule, {
   valid: [
     test({ code: 'var { a } = b;' }),
@@ -24,6 +26,21 @@ ruleTester.run('in-params', rule, {
 
     test({ code: 'function t(a, b) {}' }),
     test({ code: 'function t(a, b = (() => { const {a} = b; })) {}' }),
+
+    // single destructured param with a default value is allowed
+    // when max-params defaults to 1 (issue #46 — must not regress on the valid side)
+    test({ code: 'function t({ a } = {}) {}' }),
+    test({ code: 'function t({ a, b, c } = {}) {}' }),
+    test({ code: 'var a = ({ a } = {}) => a;' }),
+    test({ code: 'var a = ({ a, b } = { a: 1, b: 2 }) => a;' }),
+
+    // nested destructuring with defaults inside the param should not trigger
+    test({ code: 'function t({ a: { b } = {} }) {}' }),
+    test({ code: 'function t({ a: [ b ] = [] }) {}' }),
+
+    // default-value AssignmentPatterns elsewhere must not match the function check
+    test({ code: 'var [{ a } = {}] = b;' }),
+    test({ code: 'var { x: { a } = {} } = b;' }),
   ],
   invalid: [test({
     code: 'function t({ a }, b) {}',
@@ -40,5 +57,52 @@ ruleTester.run('in-params', rule, {
     test({
       code: 'function t(b, { a, d, c }) {}',
       errors,
-    })],
+    }),
+
+    // Issue #46: destructured param with a default value still counts as a
+    // destructured param. Without the fix, the AssignmentPattern wrapper
+    // hides the ObjectPattern from the rule.
+    test({
+      code: 'function t({ a } = {}, b) {}',
+      errors,
+    }),
+    test({
+      code: 'function t(b, { a } = {}) {}',
+      errors,
+    }),
+    test({
+      code: 'var a = ({ a } = {}, b) => a;',
+      errors,
+    }),
+    test({
+      code: 'var a = (b, { a } = {}) => a;',
+      errors,
+    }),
+    test({
+      code: 'function t({ a } = {}, { b } = {}) {}',
+      errors: errors.concat(errors),
+    }),
+
+    // Issue #46 with max-params: 0 — exact scenario from the bug report.
+    test({
+      code: 'function t({ timeoutSeconds = 3 } = {}) {}',
+      options: [{ 'max-params': 0 }],
+      errors: errorsZero,
+    }),
+    test({
+      code: 'var a = ({ a } = {}) => a;',
+      options: [{ 'max-params': 0 }],
+      errors: errorsZero,
+    }),
+    test({
+      code: 'function t({ a } = {}) {}',
+      options: [{ 'max-params': 0 }],
+      errors: errorsZero,
+    }),
+    test({
+      code: 'function t({ a }) {}',
+      options: [{ 'max-params': 0 }],
+      errors: errorsZero,
+    }),
+  ],
 });


### PR DESCRIPTION
When a destructured function parameter has a default value, the `ObjectPattern` is wrapped in an `AssignmentPattern`, so the function node is the grandparent. Walk through the `AssignmentPattern` in both `in-params` and `in-methods-params` before checking the function type.

Fixes #46 